### PR TITLE
ACE command auto-completion in bash

### DIFF
--- a/ace
+++ b/ace
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
+# PYTHON_ARGCOMPLETE_OK
 
+import argcomplete
 import argparse
 import atexit
 import collections
@@ -3591,6 +3593,8 @@ if __name__ == '__main__':
     if os.path.basename(sys.argv[0]) == 'correlate':
         sys.argv.insert(1, 'correlate')
 
+    # bash tab completion for argparse
+    argcomplete.autocomplete(parser)
     # parse the command line arguments
     args = parser.parse_args()
 

--- a/installer/requirements-3.6.txt
+++ b/installer/requirements-3.6.txt
@@ -51,3 +51,4 @@ vxstreamlib
 yara_scanner
 python-whois
 gglsbl-rest-client
+argcomplete==1.10.0


### PR DESCRIPTION
Pip version 1.10.0 argcomplete works without the annoying null byte warning documented here - https://github.com/kislyuk/argcomplete/issues/278
The following change causes the above warning on newer bash versions.
https://github.com/kislyuk/argcomplete/commit/2559a349c846a65b2f1afe76ff9d048c9b45cd4d

They've already fixed that issue but it's not yet included in a new pip version. So using argcomplete==1.10.0, you can run the following and then start a new bash shell to auto complete ace commands:
```
$ sudo activate-global-python-argcomplete 
Installing bash completion script /etc/bash_completion.d/python-argcomplete.sh
```