### PR TITLE
IP geolocation/metadata module with blacklist/whitelist functionality

### DIFF
--- a/ace
+++ b/ace
@@ -2445,6 +2445,26 @@ update_organization_parsers = subparsers.add_parser('update-organization',
     help="Updates the files used by the UserTaggingAnalyzer module.")
 update_organization_parsers.set_defaults(func=update_organization)
 
+def update_maxmind_databases(args):
+    import saq
+    from ip_inspector import maxmind
+
+    config = saq.CONFIG['analysis_module_ip_inspector']
+    proxies = saq.PROXIES if 'use_proxy' in config and config.getboolean('use_proxy') else None
+    license_key = config['license_key'] if 'license_key' in config else args.license_key
+    if license_key:
+        if not maxmind.update_databases(license_key=license_key, proxies=proxies):
+            logging.error("Problem updating MaxMind GeoLite2 databases.")
+            sys.exit(1)
+
+    sys.exit(0)
+
+update_maxmind_parser = subparsers.add_parser('update-maxmind-databases',
+    help="Update the local MaxMind GeoLite2 databases.")
+update_maxmind_parser.add_argument('--license-key', action='store', default=None,
+    help="Manually supply a license key.")
+update_maxmind_parser.set_defaults(func=update_maxmind_databases)
+
 # TODO move this into integration
 def update_crits_cache(args):
     from saq.crits import update_local_cache

--- a/ace
+++ b/ace
@@ -847,17 +847,18 @@ def correlate(args):
 
 # analyze-files
 correlate_parser = subparsers.add_parser('correlate',
-    help="Analyze one or more observables or alerts.")
+    help="Analyze one or more observables or alerts.",
+    epilog="Example: ace correlate ipv4 8.8.8.8 -G email -E ip_inspector -E gglsbl_service -D carbon_black_process_analysis_v1 -G common")
 correlate_parser.add_argument('--single-threaded', required=False, dest='single_threaded', default=False, action='store_true',
     help="Force execution to take place in a single process and a single thread.  Useful for manual debugging.")
-correlate_parser.add_argument('-D', '--disable-module', required=False, dest='disabled_modules', nargs='*',
-    help="Zero or more module names (substring match) to disable.")
+correlate_parser.add_argument('-D', '--disable-module', required=False, dest='disabled_modules', action='append',
+    help="Specify a module name (substring match) to disable. This option can be specified multiple times.")
 correlate_parser.add_argument('--disable-all', required=False, dest='disable_all', default=False, action='store_true',
     help="Disable all analysis modules (use -E switch to enable specific modules.")
-correlate_parser.add_argument('-E', '--enable-module', required=False, dest='enabled_modules', nargs='*', 
-    help="Zero or more module names (substring match) to enable.")
-correlate_parser.add_argument('-G', '--enable-module-group', required=False, dest='enable_module_group', nargs='+',
-    help="One or more module group names to enable.")
+correlate_parser.add_argument('-E', '--enable-module', required=False, dest='enabled_modules', action='append', 
+    help="Specify module names (substring match) to enable. This option can be specified multiple times.")
+correlate_parser.add_argument('-G', '--enable-module-group', required=False, dest='enable_module_group', action='append',
+    help="Module groups to enable by name. Specify for each module group.")
 correlate_parser.add_argument('-m', '--analysis-mode', required=False, dest='analysis_mode', 
     help="The analysis mode to use for this analysis. Defaults to cli")
 correlate_parser.add_argument('-d', '--storage-dir', required=False, dest='storage_dir', default='ace.out',
@@ -3078,9 +3079,8 @@ def verify_modules(args):
     # COPY-PASTA!!
     import importlib
 
-    for section in saq.CONFIG.sections():
-        if not section.startswith('analysis_module_'):
-            continue
+    analysis_module_sections = [section for section in saq.CONFIG.sections() if section.startswith('analysis_module_')]
+    for section in sorted(analysis_module_sections):
 
         # is this module disabled globally?
         # modules that are disable globally are not used anywhere

--- a/app/templates/analysis/alert.html
+++ b/app/templates/analysis/alert.html
@@ -100,7 +100,11 @@
     <div class="panel-heading">
         <h3 class="panel-title">Alert Details <a role="button" data-toggle="collapse" data-target="#collapse_alert_details" aria-expanded="true" aria-controls="collapse_alert_details">(hide/show)</a></h3>
     </div>
-    <div class="panel-body" id="collapse_alert_details">
+    {%if ace_config['gui'].getboolean('alert_details_collapsed') %}
+        <div class="panel-body collapse" id="collapse_alert_details">
+    {% else %}
+        <div class="panel-body" id="collapse_alert_details">
+    {% endif %}
         <!-- by default we just pretty-print the json -->
         {% block alert_details %} <pre>{{ analysis.details | pprint }}</pre> {% endblock %}
     </div>

--- a/etc/saq.default.ini
+++ b/etc/saq.default.ini
@@ -892,6 +892,11 @@ class = IPIAnalyzer
 enabled = no
 license_key =
 use_proxy = yes
+# tag_list is a comma seperated list of ip_inspector.config.FIELDS to tag by default
+#>>> from ip_inspector.maxmind import FIELDS
+#>>> FIELDS
+#['IP', 'ASN', 'ORG', 'Continent', 'Country', 'Region', 'City', 'Time Zone', 'Latitude', 'Longitude', 'Accuracy Radius']
+tag_list = Country
 
 [analysis_module_mailbox_email_analyzer]
 module = saq.modules.email

--- a/etc/saq.default.ini
+++ b/etc/saq.default.ini
@@ -248,6 +248,9 @@ upload_vt = on
 upload_vxstream = on
 view_in_vx = on
 
+; Default Alert Details toggle position
+alert_details_collapsed = no
+
 ; Hide intel if we don't want to let people see it (public/internet ace)
 hide_intel = no
 

--- a/etc/saq.default.ini
+++ b/etc/saq.default.ini
@@ -885,6 +885,14 @@ eventsentry = analysis/custom/eventsentry.html
 ;threaded_execution_frequency = 5
 ;;target_mode = correlation
 
+
+[analysis_module_ip_inspector]
+module = saq.modules.ip_address
+class = IPIAnalyzer
+enabled = no
+license_key =
+use_proxy = yes
+
 [analysis_module_mailbox_email_analyzer]
 module = saq.modules.email
 class = MailboxEmailAnalyzer
@@ -1900,6 +1908,7 @@ analysis_module_snort_signature_analysis_v1 = yes
 analysis_module_url_email_pivot_analyzer = yes
 analysis_module_user_analyzer = yes
 analysis_module_whois_analyzer = yes
+analysis_module_ip_inspector = yes
 
 [module_group_file]
 ; everything you would need for file analysis

--- a/installer/requirements-3.6.txt
+++ b/installer/requirements-3.6.txt
@@ -51,4 +51,5 @@ vxstreamlib
 yara_scanner
 python-whois
 gglsbl-rest-client
-argcomplete==1.10.0
+argcomplete
+ip-inspector

--- a/installer/source_install
+++ b/installer/source_install
@@ -206,5 +206,7 @@ fi
     #esac
 #done
 
+sudo activate-global-python-argcomplete
+
 echo next steps:
 echo "cd $SAQ_HOME && source load_environment && ace service start --daemon engine"

--- a/lib/saq/modules/__init__.py
+++ b/lib/saq/modules/__init__.py
@@ -254,6 +254,12 @@ class AnalysisModule(object):
         except KeyError:
             raise KeyError("module {} missing configuration item {}".format(self, config_name))
 
+    def verify_config_item_has_value(self, config_key):
+        """Verifies the given configuration exists and has a value. Use this from verify_environment."""
+        self.verify_config_exists(config_key)
+        if not self.config[config_key]:
+            raise TypeError("module {} cofiguration item {} is not defined.".format(self, config_key))
+
     def verify_path_exists(self, path):
         """Verifies the given path exists.  If the path is relative then it is relative to SAQ_HOME."""
         _path = path

--- a/lib/saq/modules/ip_address.py
+++ b/lib/saq/modules/ip_address.py
@@ -1,43 +1,31 @@
 
 import sys
 import logging
+
 from ip_inspector import maxmind
-from ip_inspector import Inspector
+from ip_inspector import Inspector, Inspected_IP
 
-# Keep a cache of the inspector object
-# as creating it is an expensive operation
-MaxMindInspector = None
-
-
-def refresh_maxmind_inspector(license_key):
-    """This function gets called to update the cached client when the MaxMind databases were updated"""
-    if not maxmind.update_databases(license_key=license_key):
-        logging.error("Problem updating MaxMind GeoLite2 databases.")
-        return False
-    MaxMindInspector = Inspector(maxmind.Client(license_key=license_key)
-    return True
+from saq.constants import *
+from saq.analysis import Analysis
+from saq.modules import AnalysisModule
 
 
 class IpInspectorAnalysis(Analysis):
     """What is the metadata associated to this IP address and is it whitelisted or blacklisted?
     """
-    self._inspected_ip = None
-    
+
     def initialize_details(self):
         self.details = {
                 'blacklist': None,
                 'whitelist': None,
                 'raw': None,
-                'pretty': None
+                'pretty': None,
+                'summary_strings': {'asn': None,
+                                    'org': None,
+                                    'city': None,
+                                    'country': None,
+                                    'region': None},
                 }
-
-    @inspected_ip.setter
-    def inspected_ip(self, iip: ip_inspector.Inspected_IP):
-        self._inspected_ip = iip
-
-    @property
-    def inspected_ip(self)
-        return self._inspected_ip
 
     def generate_summary(self):
         summary = "IP Inspection: "
@@ -45,13 +33,12 @@ class IpInspectorAnalysis(Analysis):
             summary += 'BLACKLISTED '
         if self.details['whitelist']:
             summary += '(whitelisted) '
-        #results = self.details['raw']
-        #asn = results['asn']['autonomous_system_number']
-        city = self.inspected_ip.get('City')
-        region = self.inspected_ip.get('Region')
-        country = self.inspected_ip.get('Country')
-        asn = self.inspected_ip.get('ASN')
-        org = self.inspected_ip.get('ORG')
+        results = self.details['summary_strings']
+        asn = results['asn']
+        city = results['city']
+        region = results['region']
+        country = results['country']
+        org = results['org']
         if city:
             summary += "{}, ".format(city)
         if region:
@@ -73,38 +60,44 @@ class IPIAnalyzer(AnalysisModule):
 
     @property
     def valid_observable_types(self):
-        return F_IPV4, F_IPV6
+        return F_IPV4
 
     @property
     def license_key(self):
         return self.config['license_key']
 
     def verify_environment(self):
-        self.verify_config_exists('license_key')
+        self.verify_config_item_has_value('license_key')
 
     def execute_analysis(self, observable):
-        logging.debug("Inspecting {}".format(observable.value))
+        logging.info("Inspecting {}".format(observable.value))
         try:
-            # Create Inspector
-            if not MaxMindInspector:
-                MaxMindInspector = Inspector(maxmind.Client(license_key=self.license_key))
-            mmi = MaxMindInspector
-
+            # Create Inspector with MaxMind API
+            mmi = Inspector(maxmind.Client(license_key=self.license_key))
             inspected_ip = mmi.inspect(observable.value)
-            if not inspected_ip:
-                logging.warning("Failed to get result for {}".format(observable.value))
-                return None
-            self.inspected_ip = inspected_ip
+
             analysis = self.create_analysis(observable)
             analysis.details['raw'] = inspected_ip.raw
-            observable.add_tag(inspected_ip.get('Country'))
-            observable.add_tag(inspected_ip.get('ORG'))
+
+            # get the most interesting details for primary use, tag some
+            country = inspected_ip.get('Country')
+            org = inspected_ip.get('ORG')
+            city = inspected_ip.get('City')
+            region = inspected_ip.get('Region')
+            asn = inspected_ip.get('ASN')
+            observable.add_tag(country)
+            observable.add_tag(org)
+            analysis.details['summary_strings']['org'] = org
+            analysis.details['summary_strings']['country'] = country
+            analysis.details['summary_strings']['asn'] = asn
+            analysis.details['summary_strings']['city'] = city
+            analysis.details['summary_strings']['region'] = region
 
             if inspected_ip.is_blacklisted:
                 logging.info("IP '{}' on blacklist for '{}'".format(inspected_ip.blacklist_reason))
-                observable.add_detection_point("IP Address '{}' on blacklist".format(inspected_ip.blacklist_reason)
+                observable.add_detection_point("IP Address '{}' on blacklist".format(inspected_ip.blacklist_reason))
                 analysis.details['blacklist'] = inspected_ip.get(inspected_ip.blacklist_reason)
-                observable.add_tag('blacklisted:{}'.format(inspected_ip.blacklist_reason) 
+                observable.add_tag('blacklisted:{}'.format(inspected_ip.blacklist_reason))
             # It shouldn't happen but it's possible an IP could hit on a blacklist and whitelist
             # for this reason, I'm making the next line an if instead of an elif to catch it.
             if inspected_ip.is_whitelisted:
@@ -113,7 +106,6 @@ class IPIAnalyzer(AnalysisModule):
                 observable.add_tag('whitelisted:{}'.format(inspected_ip.whitelist_reason))
 
             analysis.details['pretty'] = str(inspected_ip)
-            observable.add
             return True
         except Exception as e:
             logging.error("error inspecting ip address '{}' : {}".format(observable.value, e))

--- a/lib/saq/modules/ip_address.py
+++ b/lib/saq/modules/ip_address.py
@@ -1,0 +1,120 @@
+
+import sys
+import logging
+from ip_inspector import maxmind
+from ip_inspector import Inspector
+
+# Keep a cache of the inspector object
+# as creating it is an expensive operation
+MaxMindInspector = None
+
+
+def refresh_maxmind_inspector(license_key):
+    """This function gets called to update the cached client when the MaxMind databases were updated"""
+    if not maxmind.update_databases(license_key=license_key):
+        logging.error("Problem updating MaxMind GeoLite2 databases.")
+        return False
+    MaxMindInspector = Inspector(maxmind.Client(license_key=license_key)
+    return True
+
+
+class IpInspectorAnalysis(Analysis):
+    """What is the metadata associated to this IP address and is it whitelisted or blacklisted?
+    """
+    self._inspected_ip = None
+    
+    def initialize_details(self):
+        self.details = {
+                'blacklist': None,
+                'whitelist': None,
+                'raw': None,
+                'pretty': None
+                }
+
+    @inspected_ip.setter
+    def inspected_ip(self, iip: ip_inspector.Inspected_IP):
+        self._inspected_ip = iip
+
+    @property
+    def inspected_ip(self)
+        return self._inspected_ip
+
+    def generate_summary(self):
+        summary = "IP Inspection: "
+        if self.details['blacklist']:
+            summary += 'BLACKLISTED '
+        if self.details['whitelist']:
+            summary += '(whitelisted) '
+        #results = self.details['raw']
+        #asn = results['asn']['autonomous_system_number']
+        city = self.inspected_ip.get('City')
+        region = self.inspected_ip.get('Region')
+        country = self.inspected_ip.get('Country')
+        asn = self.inspected_ip.get('ASN')
+        org = self.inspected_ip.get('ORG')
+        if city:
+            summary += "{}, ".format(city)
+        if region:
+            summary += "{}, ".format(region)
+        if country:
+            summary += "{} - ".format(country)
+        summary += "AS{} - ".format(asn)
+        summary += org
+        return summary
+
+
+class IPIAnalyzer(AnalysisModule):
+    """Lookup an IP address in MaxMind's free GeoLite2 databases and wrap those results around a whitelist/blacklist check.
+    """
+
+    @property
+    def generated_analysis_type(self):
+        return IpInspectorAnalysis
+
+    @property
+    def valid_observable_types(self):
+        return F_IPV4, F_IPV6
+
+    @property
+    def license_key(self):
+        return self.config['license_key']
+
+    def verify_environment(self):
+        self.verify_config_exists('license_key')
+
+    def execute_analysis(self, observable):
+        logging.debug("Inspecting {}".format(observable.value))
+        try:
+            # Create Inspector
+            if not MaxMindInspector:
+                MaxMindInspector = Inspector(maxmind.Client(license_key=self.license_key))
+            mmi = MaxMindInspector
+
+            inspected_ip = mmi.inspect(observable.value)
+            if not inspected_ip:
+                logging.warning("Failed to get result for {}".format(observable.value))
+                return None
+            self.inspected_ip = inspected_ip
+            analysis = self.create_analysis(observable)
+            analysis.details['raw'] = inspected_ip.raw
+            observable.add_tag(inspected_ip.get('Country'))
+            observable.add_tag(inspected_ip.get('ORG'))
+
+            if inspected_ip.is_blacklisted:
+                logging.info("IP '{}' on blacklist for '{}'".format(inspected_ip.blacklist_reason))
+                observable.add_detection_point("IP Address '{}' on blacklist".format(inspected_ip.blacklist_reason)
+                analysis.details['blacklist'] = inspected_ip.get(inspected_ip.blacklist_reason)
+                observable.add_tag('blacklisted:{}'.format(inspected_ip.blacklist_reason) 
+            # It shouldn't happen but it's possible an IP could hit on a blacklist and whitelist
+            # for this reason, I'm making the next line an if instead of an elif to catch it.
+            if inspected_ip.is_whitelisted:
+                logging.info("IP '{}' on whitelist for '{}'".format(inspected_ip.whitelist_reason))
+                analysis.details['whitelist'] = inspected_ip.get(inspected_ip.whitelist_reason)
+                observable.add_tag('whitelisted:{}'.format(inspected_ip.whitelist_reason))
+
+            analysis.details['pretty'] = str(inspected_ip)
+            observable.add
+            return True
+        except Exception as e:
+            logging.error("error inspecting ip address '{}' : {}".format(observable.value, e))
+            return False

--- a/lib/saq/modules/test_ip_address.py
+++ b/lib/saq/modules/test_ip_address.py
@@ -1,0 +1,184 @@
+# vim: sw=4:ts=4:et
+
+import os
+import logging
+import unittest
+
+import saq, saq.test
+from saq.constants import *
+from saq.test import *
+
+
+class TestCase(ACEModuleTestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.blacklists = {
+                  "ASN": "test_data/asn_blacklist.txt",
+                  "Country": "test_data/country_blacklist.txt",
+                  "ORG": "test_data/org_blacklist.txt"
+                }
+        self.whitelists = {
+                  "ASN": "test_data/asn_whitelist.txt",
+                  "ORG": "test_data/org_whitelist.txt"
+                }
+        
+        for _, bl_path in self.blacklists.items():
+            with open(bl_path, 'a'):
+                os.utime(bl_path)
+            self.assertTrue(os.path.exists(bl_path))
+        for _, wl_path in self.whitelists.items():
+            with open(wl_path, 'a'):
+                os.utime(wl_path)
+            self.assertTrue(os.path.exists(wl_path))
+
+    def fresh_ipi(self, license_key):
+        from ip_inspector import maxmind, Inspector
+        return Inspector(mmc=maxmind.Client(license_key=license_key),
+                                     blacklists=self.blacklists,
+                                     whitelists=self.whitelists)
+
+    def setUp(self):
+        ACEModuleTestCase.setUp(self)
+
+    def tearDown(self):
+        ACEModuleTestCase.tearDown(self)
+        for _, bl_path in self.blacklists.items():
+            try:
+                os.remove(bl_path)
+            except FileNotFoundError:
+                pass
+        for _, wl_path in self.whitelists.items():
+            try:
+                os.remove(wl_path)
+            except FileNotFoundError:
+                pass
+
+    def test_ip_lookup(self):
+        """Make sure lookup is working by using a known static value: 8.8.8.8"""
+
+        from saq.modules.ip_address import IpInspectorAnalysis
+
+        config = saq.CONFIG['analysis_module_ip_inspector']
+        if config.getboolean('enabled'):
+            self.skipTest("Module not enabled.")
+        if 'license_key' not in config:
+            self.skipTest("Missing license_key")
+        if not config['license_key']:
+            self.skipTest("License key not defined.")
+
+        root = create_root_analysis()
+        root.initialize_storage()
+        ipv4 = root.add_observable(F_IPV4, '8.8.8.8')
+        root.save()
+        root.schedule()
+
+        engine = TestEngine()
+        engine.enable_module('analysis_module_ip_inspector', 'test_groups')
+        engine.controlled_stop()
+        engine.start()
+        engine.wait()
+
+        root.load()
+        ipv4 = root.get_observable(ipv4.id)
+        analysis = ipv4.get_analysis(IpInspectorAnalysis)
+        self.assertEquals(analysis.org, 'GOOGLE')
+        self.assertEquals(analysis.asn, 15169)
+        self.assertIsNone(analysis.region)
+
+    def test_undefined_lookup(self):
+        """Lookup an IP that's not in the database."""
+        from saq.modules.ip_address import IpInspectorAnalysis
+
+        config = saq.CONFIG['analysis_module_ip_inspector']
+        if config.getboolean('enabled'):
+            self.skipTest("Module not enabled.")
+        if 'license_key' not in config:
+            self.skipTest("Missing license_key")
+        if not config['license_key']:
+            self.skipTest("License key not defined.")
+
+        root = create_root_analysis()
+        root.initialize_storage()
+        ipv4 = root.add_observable(F_IPV4, '10.10.10.10')
+        root.save()
+        root.schedule()
+
+        engine = TestEngine()
+        engine.enable_module('analysis_module_ip_inspector', 'test_groups')
+        engine.controlled_stop()
+        engine.start()
+        engine.wait()
+
+        root.load()
+        ipv4 = root.get_observable(ipv4.id)
+        analysis = ipv4.get_analysis(IpInspectorAnalysis)
+
+        self.assertFalse(analysis)
+        with self.assertLogs('root', level='WARN') as cm:
+           logging.getLogger('root').warn('Problem inspecting ip=10.10.10.10 : The address 10.10.10.10 is not in the database.')
+
+        self.assertEqual(cm.output, ['WARNING:root:Problem inspecting ip=10.10.10.10 : The address 10.10.10.10 is not in the database.'])
+
+    def test_update_maxmind_databases(self):
+        """Download MaxMind GeoLite2 databases"""
+        from ip_inspector import maxmind
+
+        config = saq.CONFIG['analysis_module_ip_inspector']
+        if config.getboolean('enabled'):
+            self.skipTest("Module not enabled.")
+        if 'license_key' not in config:
+            self.skipTest("Missing license_key")
+        if not config['license_key']:
+            self.skipTest("License key not defined.")
+
+        proxies = saq.PROXIES if 'use_proxy' in config and config.getboolean('use_proxy') else None
+        license_key = config['license_key']
+        self.assertTrue(maxmind.update_databases(license_key=license_key, proxies=proxies))
+
+    def test_blacklist_set(self):
+        """Test blacklist setting"""
+        import ip_inspector
+
+        config = saq.CONFIG['analysis_module_ip_inspector']
+        if config.getboolean('enabled'):
+            self.skipTest("Module not enabled.")
+        if 'license_key' not in config:
+            self.skipTest("Missing license_key")
+        if not config['license_key']:
+            self.skipTest("License key not defined.")
+
+        ipi = ip_inspector.Inspector(mmc=ip_inspector.maxmind.Client(license_key=config['license_key']),
+                                     blacklists=self.blacklists,
+                                     whitelists=self.whitelists)
+
+        iip = ipi.inspect('8.8.8.8')
+        self.assertFalse(iip.is_blacklisted)
+        iip.set_blacklist('ORG')
+        self.assertTrue(iip.is_blacklisted)
+        self.assertEquals(iip.blacklist_reason, 'ORG')
+        self.assertEquals(iip.reason, 'GOOGLE')
+
+    def test_blacklist_file(self):
+        """Blacklist check against files"""
+        import ip_inspector
+
+        config = saq.CONFIG['analysis_module_ip_inspector']
+        if config.getboolean('enabled'):
+            self.skipTest("Module not enabled.")
+        if 'license_key' not in config:
+            self.skipTest("Missing license_key")
+        if not config['license_key']:
+            self.skipTest("License key not defined.")
+
+        # get a fresh object
+        ipi = self.fresh_ipi(config['license_key'])
+
+        iip = ipi.inspect('8.8.8.8')
+        list_path = self.blacklists['ORG']
+        self.assertTrue(ip_inspector.append_to_('blacklist', iip, list_path=list_path))
+        ipi = self.fresh_ipi(config['license_key'])
+        self.assertTrue(ipi.inspect('8.8.8.8').is_blacklisted)
+        self.assertTrue(ip_inspector.remove_from_('blacklist', iip, list_path=list_path))
+        ipi = self.fresh_ipi(config['license_key'])
+        self.assertFalse(ipi.inspect('8.8.8.8').is_blacklisted)


### PR DESCRIPTION
TL;DR:

- ip geolocation & metadata currently based on maxmind's free databases
- ip_inspector detection based on org, asn, country blacklists (or more if you create the files and point to them)
- if something is blacklisted, a detection point is made
- `ace update-maxmind-databases` command to download/update the databases (they release updates every Tuesday). I put this command in a crontab for the ace user.
- Where to get a license key: https://www.maxmind.com/en/geolite2/signup

Also I just realized I forgot to make the location of any blacklist or whitelists more configurable.. I will do that if needed. Currently the default lists will get populated at the following location and can be manually edited there, or the `ip-inspector` script has functionality for it.
```
~ace_user/.ip_inspector/etc/*_blacklist.txt
~ace_user/.ip_inspector/etc/*_whitelist.txt
```

Everything is turned off by default.

Other un-related things in the PR:

- fixed order or arguments on the `ace correlate` command so any order will now work. Kick this back if you don't like how I did that
- called activate-global-python-argcomplete at the end of ace source instal so argument completion in bash gets turned on by default at install time
- made alert details section default collapse state configurable


The long version:

We needed a moderately accurate ip geolocation module to enrich some alerts for the analyst to make a quicker disposition. I used MaxMind's free GeoLite2 databases and wrapped a library around the maxmind api to access those databases.

Additionally, we've also been experimenting with detection based on the metadata we see on IP addresses at the output of a couple hunts (mostly user authentication/cloud access). So there is a simple blacklist/whitelist functionality built in as well. I've found some value in this.. so eventually I want to replace some side scripts with a hunt that submits any results to ace in 'analysis' mode and then this ip_inspector module will move the analysis to correlation mode if a blacklist match is made. 

The library the module is based on is currently [here](https://github.com/seanmcfeely/ip-inspector) but I plan on moving that repo to ace-ecosystem if it shows value. Otherwise, a simpler geolocation module could be built directly into ace by grabbing a few code sections from that library. I started to write the ip_inspector  package to be modular as I was experimenting with a couple paid IP intel APIs. However now it only uses the maxmind api.

If you want to turn the ip_inspector module on you can get a free license key here:  https://www.maxmind.com/en/geolite2/signup

