### PR TITLE
ParseURLAnalyzer && FQDNAnalyzer && more configurable IPIAnalyzer

### DIFF
--- a/etc/saq.default.ini
+++ b/etc/saq.default.ini
@@ -873,6 +873,8 @@ use_proxy = yes
 #>>> FIELDS
 #['IP', 'ASN', 'ORG', 'Continent', 'Country', 'Region', 'City', 'Time Zone', 'Latitude', 'Longitude', 'Accuracy Radius']
 tag_list = Country
+; Point to a local YAML or JSON config for any customizations 
+override_config_path = 
 
 [analysis_module_mailbox_email_analyzer]
 module = saq.modules.email

--- a/etc/saq.default.ini
+++ b/etc/saq.default.ini
@@ -1010,6 +1010,18 @@ enabled = yes
 ; use this if you are in AWS and your target is inside target network
 ssh_host = 
 
+[analysis_module_parse_url]
+; Parse URL and add FQDN observable
+module = saq.modules.url
+class = ParseURLAnalyzer
+enabled = no
+
+[analysis_module_fqdn_analyzer]
+; Add ip observables for FQDN resolutions
+module = saq.modules.dns
+class = FQDNAnalyzer
+enabled = no
+
 [analysis_module_dns_analyzer]
 module = saq.modules.asset
 class = DNSAnalyzer


### PR DESCRIPTION
I wanted to resolve the FQDN of URL observables for IPV4 inspection after I noticed we would have alerted on something we didn't because of network blacklisting.

I added the following very simple modules:
- ParseURLAnalyzer --> [will help with this](https://github.com/ace-ecosystem/ACE/issues/66), @krayzpipes 
- FQDNAnalyzer

I debated turning on both of those by default but did not. They're disabled by default.

Also, this PR includes some code I needed for the ip_inspector module to be more configurable.
