### PR TITLE
Removed setting the gid for the ace user in the dev container.

### DIFF
--- a/Dockerfile.ace-base
+++ b/Dockerfile.ace-base
@@ -6,7 +6,7 @@ ENV TZ UTC
 ENV DEBIAN_FRONTEND noninteractive
 ARG SAQ_USER_ID=1000
 ARG SAQ_GROUP_ID=1000
-RUN groupadd ace -g $SAQ_GROUP_ID \
+RUN groupadd ace \
     && useradd -g ace -G sudo -m -s /bin/bash -u $SAQ_USER_ID ace \
     && sed -i -e 's/main$/main contrib non-free/g' /etc/apt/sources.list \
     && apt -y update \


### PR DESCRIPTION
When I realized that the local user ids and the ids used in the docker
container need to match up I changed it so that when the adduser is
executed to create the Docker container it is passed the current user's
UID and GID.

However, on a mac the GID is a super low number that is already used by
the Debain-based container. So I removed the GID setting.