### PR TITLE
Small changes when mediawiki is enabled.

### DIFF
--- a/app/static/js/ace.js
+++ b/app/static/js/ace.js
@@ -171,7 +171,7 @@ function select_event_name_candidate_from_manage_view() {
 
         // only consider alert event name candidates that have finished analyzing
         let alert_analysis_status = document.getElementById(`alert_status_${checked_alert_uuid}`).innerHTML
-        if (alert_analysis_status !== "Completed") return;
+        if (!alert_analysis_status.includes("Completed")) return;
 
         let checked_alert_date = new Date(document.getElementById(`alert_date_${checked_alert_uuid}`).title);
         // base case -- set first 'earliest_date' with first date we check

--- a/app/templates/events/manage.html
+++ b/app/templates/events/manage.html
@@ -48,7 +48,7 @@
                         <td class="event-cell"><button onclick="load_event_alerts('{{event.id}}')" type="button" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-triangle-right"></span></button></td>
                         <td class="event-cell"><button onclick="edit_event('{{event.id}}')" type="button" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></button></td>
                         <td class="event-cell">{{event.creation_date}}</td>
-                        <td class="event-cell">{{event.type}} - {{event.vector}} - <a target="_blank" href="{{url_for('events.index', direct=event.id)}}">{{event.name}}</a>{% if event.wiki %} | <a href="{{ event.wiki }}" target="_blank">Wiki</a>{% endif %}</td>
+                        <td class="event-cell">{{event.type}} - {{event.vector}} - {% if event.wiki %}<a href="{{ event.wiki }}" target="_blank">Wiki</a>{% endif %} | <a target="_blank" href="{{url_for('events.index', direct=event.id)}}">{{event.name}}</a></td>
                         <td>
                             {% for t in event.threats %}
                             <span class="label label-default">{{t}}</span>

--- a/app/templates/events/user_analysis.html
+++ b/app/templates/events/user_analysis.html
@@ -15,7 +15,7 @@
             {% if 'ldap' in user.jinja_details %}
                 <tr>
                     <td>
-                        {% if 'cn' in user.jinja_details['ldap'] %}
+                        {% if 'cn' in user.jinja_details['ldap'] and user.jinja_details['ldap'] %}
                             {{ user.jinja_details['ldap']['cn'] }}
                         {% endif %}
                     </td>

--- a/etc/saq.default.ini
+++ b/etc/saq.default.ini
@@ -402,6 +402,9 @@ domain = https://wiki.local/
 uri = https://wiki.local/display/integral/AlertContext
 ; url suffix for alert documentation
 alert_suffix = #AlertContext-
+; How many possible name tags to pass in the name recommendation.
+; The code forces a name_recomendation_depth minimum of 2.
+name_recomendation_depth = 3
 
 [phishme]
 enabled = no

--- a/saq/analysis/__init__.py
+++ b/saq/analysis/__init__.py
@@ -3910,7 +3910,11 @@ class RootAnalysis(Analysis):
             possible_tags.append('Unknown')
         possible_tags.append(self.uuid)
 
-        result = f'{yyyymmdd}-{self.alert_type.replace(" ", "")}-{possible_tags[0]}-{possible_tags[1]}'
+        if saq.CONFIG['mediawiki'].getboolean('enabled'):
+            # remove the date and alert_type from the recommendation
+            result = f'{possible_tags[0]}-{possible_tags[1]}'
+        else:
+            result = f'{yyyymmdd}-{self.alert_type.replace(" ", "")}-{possible_tags[0]}-{possible_tags[1]}'
 
         # Remove any invalid characters from the name
         invalid_chars = re.findall(r'[^a-zA-Z0-9-. ]', result)

--- a/saq/analysis/__init__.py
+++ b/saq/analysis/__init__.py
@@ -3913,6 +3913,10 @@ class RootAnalysis(Analysis):
         if saq.CONFIG['mediawiki'].getboolean('enabled'):
             # remove the date and alert_type from the recommendation
             result = f'{possible_tags[0]}-{possible_tags[1]}'
+            _name_depth = saq.CONFIG['mediawiki'].getint('name_recomendation_depth', 2)
+            if _name_depth > 2 and len(possible_tags) > _name_depth:
+                for tag in possible_tags[2:_name_depth]:
+                    result += f'-{tag}'
         else:
             result = f'{yyyymmdd}-{self.alert_type.replace(" ", "")}-{possible_tags[0]}-{possible_tags[1]}'
 


### PR DESCRIPTION
Don't append the date to the event name recommendation. We don't want to add validation to other tools for this. Also, we didn't want the alert_type in the recommended event name. Finally, I changed the order of the links on the manage event page.