### PR TITLE
Cloudphish recording redirection target URLs

### DIFF
--- a/saq/modules/cloudphish.py
+++ b/saq/modules/cloudphish.py
@@ -400,8 +400,15 @@ class CloudphishAnalyzer(AnalysisModule):
 
         # Was there a redirection URL to add as an observable?
         if response.get('redirection_target_url'):
+            from saq.modules.url import CrawlphishAnalyzer
+            from saq.modules.render import RenderAnalyzer
             final_url = analysis.add_observable(F_URL, response['redirection_target_url'])
             final_url.add_tag('redirection_target')
+            final_url.add_relationship(R_REDIRECTED_FROM, url)
+            final_url.exclude_analysis(RenderAnalyzer)
+            final_url.exclude_analysis(CrawlphishAnalyzer)
+            final_url.exclude_analysis(CloudphishAnalyzer)
+            analysis.iocs.add_url_iocs(final_url.value, tags=['crawlphish', 'redirection_target'])
 
         # save the analysis results
         analysis.query_result = response

--- a/saq/modules/cloudphish.py
+++ b/saq/modules/cloudphish.py
@@ -398,6 +398,11 @@ class CloudphishAnalyzer(AnalysisModule):
             analysis.result_details = 'EMPTY CONTENT'
             return True
 
+        # Was there a redirection URL to add as an observable?
+        if response.get('redirection_target_url'):
+            final_url = analysis.add_observable(F_URL, response['redirection_target_url'])
+            final_url.add_tag('redirection_target')
+
         # save the analysis results
         analysis.query_result = response
 
@@ -483,6 +488,7 @@ class CloudphishAnalyzer(AnalysisModule):
                 logging.error("unable to download file {} for url {} from cloudphish: {}".format(
                               target_file, url.value, e))
                 report_exception()
+
 
         return True
 
@@ -613,12 +619,18 @@ class CloudphishRequestAnalyzer(AnalysisModule):
 
             break
 
+        # if there was a redirection url
+        redirection_target_url = None
+        if crawlphish_analysis.final_url and crawlphish_analysis.final_url != url.value:
+            redirection_target_url = crawlphish_analysis.final_url
+
         update_cloudphish_result(sha256_url, 
                                  http_result_code=http_result_code,
                                  http_message=http_message,
                                  result=scan_result,
                                  sha256_content=sha256_content,
-                                 status=STATUS_ANALYZED)
+                                 status=STATUS_ANALYZED,
+                                 redirection_target_url=redirection_target_url)
 
         if sha256_content:
             update_content_metadata(sha256_content, saq.SAQ_NODE, file_name)

--- a/saq/modules/url.py
+++ b/saq/modules/url.py
@@ -915,6 +915,8 @@ class CrawlphishAnalyzer(AnalysisModule):
         analysis.file_name = file_name
         analysis.requested_url = formatted_url
         analysis.final_url = response.url
+        if analysis.final_url.endswith('/'):
+            analysis.final_url = analysis.final_url[:-1]
 
         # if the final url is different than the original url, record that url as an observable
         final_url = None

--- a/sql/01-ace.sql
+++ b/sql/01-ace.sql
@@ -99,6 +99,7 @@ CREATE TABLE `cloudphish_analysis_results` (
   `insert_date` datetime NOT NULL COMMENT 'When this entry was created.',
   `uuid` varchar(36) CHARACTER SET ascii NOT NULL COMMENT 'The UUID of the analysis. This would also become the UUID of the alert if it ends up becoming one.',
   `status` enum('NEW','ANALYZING','ANALYZED') NOT NULL DEFAULT 'NEW',
+  `redirection_target_url` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci COMMENT 'The value of a redirection target URL.',
   PRIMARY KEY (`sha256_url`),
   KEY `insert_date_index` (`insert_date`),
   KEY `sha256_content_index` (`sha256_content`)

--- a/updates/sql/ace/00023.sql
+++ b/updates/sql/ace/00023.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `cloudphish_analysis_results`
+ADD COLUMN `redirection_target_url` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci COMMENT 'The value of a URL that the redirection target.' AFTER `status`;

--- a/updates/sql/ace/patch.list
+++ b/updates/sql/ace/patch.list
@@ -20,3 +20,4 @@ updates/sql/ace/00019.sql
 updates/sql/ace/00020.sql
 updates/sql/ace/00021.sql
 updates/sql/ace/00022.sql
+updates/sql/ace/00023.sql


### PR DESCRIPTION
We missed a phish because Cloudphish wasn't aware of a
redirection target URL identified by Crawlphish. This little
patch records redirection target URLs so an observable can be
created.